### PR TITLE
Updates an import's var name to match change at source ( sampleWhite --> sampleWhiteDeck )

### DIFF
--- a/__tests__/dealCards.test.js
+++ b/__tests__/dealCards.test.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const { sampleWhite } = require('../src/vars/sampleData.js')
-// console.log(sampleWhite);
-const whiteDeck = sampleWhite.slice();
+const { sampleWhiteDeck } = require('../src/vars/sampleData.js')
+
+const whiteDeck = sampleWhiteDeck.slice();
 
 let players = [
   {
@@ -21,7 +21,7 @@ let players = [
     userName: 'Hospital Fire'
   }
 ];
-// test variables 
+
 
 let cardsDealt = [];
 
@@ -36,8 +36,7 @@ function dealCards() {
     }
     cardsDealt.push(handOfCards.slice())
     players[idx].handOfCards = handOfCards;
-  
-    // CAS.to(player.socketId).emit('hand of white cards', { handOfCards });
+ 
   });
   cardsDealt.flat();  
 }
@@ -60,9 +59,3 @@ describe('Testing dealCards function', () => {
     }
   });
 });
-
-// describe('', () => {
-//   it('', () => {
-//     expect().toBe();
-//   })
-// })


### PR DESCRIPTION
`sampleWhite` was changed to `sampleWhiteDeck` in sampleData.js, but the import of that variable in dealCards.test.js hadn't been updated to match, which was causing a test to fail. This PR updates the import's name to match the source, enabling the test to run and pass again:

<img width="583" alt="image" src="https://user-images.githubusercontent.com/65784446/153558860-d9bd476e-0af6-441a-82d2-924c42186deb.png">
